### PR TITLE
Suppress deprecation warning

### DIFF
--- a/test/sample_app.rb
+++ b/test/sample_app.rb
@@ -23,6 +23,7 @@ class SampleApp < Rails::Application
   config.secret_key_base = "99f19f08db7a37bdcb9d6701f54dca"
   config.eager_load = true
   config.active_support.deprecation = :log
+  config.load_defaults Rails.version.split(".")[..1].join(".")
 
   # Introduced by Rails 6.
   config.hosts << "example.org" if config.respond_to?(:hosts)


### PR DESCRIPTION
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format for more information on how to upgrade.
 (called from <top (required)> at /home/runner/work/browser/browser/test/sample_app.rb:55)